### PR TITLE
Bug fix for recently copied print-doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 classes/
 lib/
 swank-clojure*jar
-Manifest.txt
 pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 classes/
 lib/
+multi-lib/
 swank-clojure*jar
 pom.xml

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ Note that due to a bug in clojure-maven-plugin, you currently cannot
 include it as a test-scoped dependency; it must be compile-scoped. You
 also cannot change the port from Maven; it's hard-coded to 4005.
 
+Put this in your Emacs configuration to get syntax highlighting in the
+slime repl:
+
+    (add-hook 'slime-repl-mode-hook 'clojure-mode-font-lock-setup)
+
 ## Connecting with SLIME
 
 Install the "slime-repl" package from ELPA using package.el. When you

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ You can embed Swank Clojure in your project, start the server from
 within your own code, and connect via Emacs to that instance:
 
     (ns my-app
-      (:use [swank.swank :as swank]))
-    (swank/start-repl) ;; optionally takes a port argument
+      (:require [swank.swank]))
+    (swank.swank/start-repl) ;; optionally takes a port argument
 
 Then use M-x slime-connect to connect from within Emacs.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,19 @@ from within Emacs.
 
 ## Usage
 
-Add Swank Clojure to your project as a development dependency to your
-project. If you are using Leiningen, add it to your project.clj file
-under :dev-dependencies:
+If you just want a standalone swank server with no third-party
+libraries, you can just install swank-clojure using Leiningen.
+
+    $ lein install swank-clojure 1.3.0-SNAPSHOT
+    $ ~/.lein/bin/swank-clojure
+
+    M-x slime-connect
+
+If you put ~/.lein/bin on your $PATH it's even more convenient.
+
+To use Swank Clojure in your project, add it as a development
+dependency. If you are using Leiningen, add it to your project.clj
+file under :dev-dependencies:
 
     :dev-dependencies [[swank-clojure "1.2.1"]]
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,16 @@ also cannot change the port from Maven; it's hard-coded to 4005.
 
 ## Connecting with SLIME
 
-Install the "slime-repl" package [from ELPA](http://tromey.com/elpa)
-using package.el. When you perform the installation, you will see
-warnings related to the byte-compilation of the packages. This is
-**normal**; the packages will work just fine even if there are
-problems byte-compiling it upon installation.
+Install the "slime-repl" package from ELPA using package.el. When you
+perform the installation, you will see warnings related to the
+byte-compilation of the packages. This is **normal**; the packages
+will work just fine even if there are problems byte-compiling it upon
+installation.
+
+There is a known bug in the latest release of package.el that can
+cause packages to fail to install in certain circumstances. The
+[version with the fixes applied](http://github.com/technomancy/package.el)
+is available on Github.
 
 Then you should be able to connect to the swank server you launched:
 

--- a/README.md
+++ b/README.md
@@ -56,16 +56,21 @@ slime repl:
 
 ## Connecting with SLIME
 
-Install the "slime-repl" package from ELPA using package.el. When you
-perform the installation, you will see warnings related to the
-byte-compilation of the packages. This is **normal**; the packages
+Install the "slime-repl" package using package.el. If you are using
+Emacs 23, it's best to get [the latest version of package.el from
+Emacs
+trunk](http://repo.or.cz/w/emacs.git/blob_plain/HEAD:/lisp/emacs-lisp/package.el). Then
+add Technomancy as an archive source:
+
+    (add-to-list 'package-archives
+                 '("technomancy" . "http://repo.technomancy.us/emacs/") t)
+
+Then you can do <kbd>M-x package-install</kbd> and choose slime-repl.
+
+When you perform the installation, you will see warnings related to
+the byte-compilation of the packages. This is **normal**; the packages
 will work just fine even if there are problems byte-compiling it upon
 installation.
-
-There is a known bug in the latest release of package.el that can
-cause packages to fail to install in certain circumstances. The
-[version with the fixes applied](http://github.com/technomancy/package.el)
-is available on Github.
 
 Then you should be able to connect to the swank server you launched:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add Swank Clojure to your project as a development dependency to your
 project. If you are using Leiningen, add it to your project.clj file
 under :dev-dependencies:
 
-    :dev-dependencies [[swank-clojure "1.2.0"]]
+    :dev-dependencies [[swank-clojure "1.2.1"]]
 
 Once you run "lein deps" you can launch a swank server from the
 command line:
@@ -28,7 +28,7 @@ If you're using Maven, add this to your pom.xml under the
     <dependency>
       <groupId>swank-clojure</groupId>
       <artifactId>swank-clojure</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1</version>
     </dependency>
 
 Then you can launch a swank server like so:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ slime repl:
 Install the "slime-repl" package using package.el. If you are using
 Emacs 23, it's best to get [the latest version of package.el from
 Emacs
-trunk](http://repo.or.cz/w/emacs.git/blob_plain/HEAD:/lisp/emacs-lisp/package.el). Then
+trunk](http://bit.ly/pkg-el). Then
 add Technomancy as an archive source:
 
     (add-to-list 'package-archives

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ using a system-wide package manager like apt-get may cause issues.
 
 Commonly-used SLIME commands:
 
-* **M-TAB**: Autocomplete symbol at point
+* **C-c TAB**: Autocomplete symbol at point
 * **C-x C-e**: Eval the form under the point
 * **C-c C-k**: Compile the current buffer
 * **M-.**: Jump to the definition of a var

--- a/TODO.org
+++ b/TODO.org
@@ -8,7 +8,8 @@ TODO
 ** M-. should work for namespaces
 ** xref for all callers of a function?
 * Piggyback elisp code in jars
-* Integrate with debug-repl
+* Type-hint-based completion for java interop
+* optionally pprint return values at repl
 * Known bugs
 ** TODO SLIME Inspector breaks in Emacs 22
 ** TODO *in* only works from *inferior-lisp*

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject swank-clojure "1.2.1"
+(defproject swank-clojure "1.3.0-SNAPSHOT"
   :description "Swank server connecting Clojure to Emacs SLIME"
   :url "http://github.com/technomancy/swank-clojure"
   :dev-dependencies [[org.clojure/clojure "1.2.0-master-SNAPSHOT"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject swank-clojure "1.2.0"
+(defproject swank-clojure "1.2.1"
   :description "Swank server connecting Clojure to Emacs SLIME"
   :url "http://github.com/technomancy/swank-clojure"
   :dev-dependencies [[org.clojure/clojure "1.2.0-master-SNAPSHOT"]])

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (defproject swank-clojure "1.3.0-SNAPSHOT"
   :description "Swank server connecting Clojure to Emacs SLIME"
   :url "http://github.com/technomancy/swank-clojure"
-  :dependencies [[org.clojure/clojure "1.2.0-beta1"]]
+  :dependencies [[org.clojure/clojure "1.3.0-master-SNAPSHOT"]]
   :shell-wrapper {:main swank.swank})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
 (defproject swank-clojure "1.3.0-SNAPSHOT"
   :description "Swank server connecting Clojure to Emacs SLIME"
   :url "http://github.com/technomancy/swank-clojure"
-  :dev-dependencies [[org.clojure/clojure "1.2.0-master-SNAPSHOT"]])
+  :dev-dependencies [[org.clojure/clojure "1.2.0-beta1"]])

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,9 @@
 (defproject swank-clojure "1.3.0-SNAPSHOT"
   :description "Swank server connecting Clojure to Emacs SLIME"
   :url "http://github.com/technomancy/swank-clojure"
-  :dependencies [[org.clojure/clojure "1.3.0-master-SNAPSHOT"]]
+  :dependencies [[org.clojure/clojure "1.2.0"]]
+  :dev-dependencies [[lein-multi "1.0.0"]]
+  :multi-deps {"1.1" [[org.clojure/clojure "1.1.0"]
+                      [org.clojure/clojure-contrib "1.1.0"]]
+               "1.3" [[org.clojure/clojure "1.3.0-master-SNAPSHOT"]]}
   :shell-wrapper {:main swank.swank})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
 (defproject swank-clojure "1.3.0-SNAPSHOT"
   :description "Swank server connecting Clojure to Emacs SLIME"
   :url "http://github.com/technomancy/swank-clojure"
-  :dev-dependencies [[org.clojure/clojure "1.2.0-beta1"]])
+  :dependencies [[org.clojure/clojure "1.2.0-beta1"]]
+  :shell-wrapper {:main swank.swank})

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -1,17 +1,26 @@
 (ns leiningen.swank
+  "Launch swank server for Emacs to connect."
   (:use [leiningen.compile :only [eval-in-project]])
   (:import [java.io File]))
 
 (defn swank-form [project port host opts]
+  ;; bootclasspath workaround: http://dev.clojure.org/jira/browse/CLJ-673
+  (when (:eval-in-leiningen project)
+    (require '[clojure walk template stacktrace]))
   `(do
      (let [is# ~(:repl-init-script project)]
        (when (.exists (File. (str is#)))
          (load-file is#)))
      (require '~'swank.swank)
+     (require '~'swank.commands.basic)
      (@(ns-resolve '~'swank.swank '~'start-repl)
-      (Integer. ~port)
-      ~@(concat (map read-string opts)
-                [:host host]))))
+      (Integer. ~port) ~@(concat (map read-string opts)
+                                 [:host host]))
+     ;; This exits immediately when using :eval-in-leiningen; must block
+     (when ~(:eval-in-leiningen project)
+       (doseq [t# ((ns-resolve '~'swank.commands.basic
+                               '~'get-thread-list))]
+         (.join t#)))))
 
 (defn swank
   "Launch swank server for Emacs to connect. Optionally takes PORT and HOST."

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -11,6 +11,6 @@
 (defn swank
   "Launch swank server for Emacs to connect. Optionally takes PORT and HOST."
   ([project port host & opts]
-     (eval-in-project project (swank-form post host opts)))
+     (eval-in-project project (swank-form port host opts)))
   ([project port] (swank project port "localhost"))
   ([project] (swank project 4005)))

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -8,7 +8,7 @@
   ([project port host & opts]
      (eval-in-project project
                       `(do
-                         (let [is# ~(:init-script project)
+                         (let [is# ~(:repl-init-script project)
                                gis# ~(get-global-init-script)]
                            (when (not (nil? gis#))
                              (load-file gis#))

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -5,7 +5,11 @@
   "Launch swank server for Emacs to connect. Optionally takes PORT and HOST."
   ([project port host & opts]
      (eval-in-project project
-                      `(do (require '~'swank.swank)
+                      `(do
+                         (let [is# ~(:init-script project)]
+                           (when is#
+                             (load-file is#)))
+                         (require '~'swank.swank)
                            (@(ns-resolve '~'swank.swank '~'start-repl)
                             (Integer. ~port)
                             ~@(concat (map read-string opts)

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -8,10 +8,7 @@
   ([project port host & opts]
      (eval-in-project project
                       `(do
-                         (let [is# ~(:repl-init-script project)
-                               gis# ~(get-global-init-script)]
-                           (when (not (nil? gis#))
-                             (load-file gis#))
+                         (let [is# ~(:repl-init-script project)]
                            (when (and (not (nil? is#)) (.exists (File. (str is#))))
                              (load-file is#)))
                          (require '~'swank.swank)

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -1,14 +1,16 @@
 (ns leiningen.swank
   (:use [leiningen.compile :only [eval-in-project]]))
 
+(defn swank-form [port host opts]
+  `(do (require '~'swank.swank)
+       (@(ns-resolve '~'swank.swank '~'start-repl)
+        (Integer. ~port)
+        ~@(concat (map read-string opts)
+                  [:host host]))))
+
 (defn swank
   "Launch swank server for Emacs to connect. Optionally takes PORT and HOST."
   ([project port host & opts]
-     (eval-in-project project
-                      `(do (require '~'swank.swank)
-                           (@(ns-resolve '~'swank.swank '~'start-repl)
-                            (Integer. ~port)
-                            ~@(concat (map read-string opts)
-                                      [:host host])))))
+     (eval-in-project project (swank-form post host opts)))
   ([project port] (swank project port "localhost"))
   ([project] (swank project 4005)))

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -2,10 +2,10 @@
   (:use [leiningen.compile :only [eval-in-project]])
   (:import [java.io File]))
 
-(defn swank-form [port host opts]
+(defn swank-form [project port host opts]
   `(do
      (let [is# ~(:repl-init-script project)]
-       (when (and is# (.exists (File. is#)))
+       (when (.exists (File. (str is#)))
          (load-file is#)))
      (require '~'swank.swank)
      (@(ns-resolve '~'swank.swank '~'start-repl)
@@ -16,6 +16,6 @@
 (defn swank
   "Launch swank server for Emacs to connect. Optionally takes PORT and HOST."
   ([project port host & opts]
-     (eval-in-project project (swank-form port host opts)))
+     (eval-in-project project (swank-form project port host opts)))
   ([project port] (swank project port "localhost"))
   ([project] (swank project 4005)))

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -1,6 +1,5 @@
 (ns leiningen.swank
-  (:use [leiningen.compile :only [eval-in-project]]
-        [leiningen.core :only [get-global-init-script]])
+  (:use [leiningen.compile :only [eval-in-project]])
   (:import [java.io File]))
 
 (defn swank

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -1,5 +1,6 @@
 (ns leiningen.swank
-  (:use [leiningen.compile :only [eval-in-project]]))
+  (:use [leiningen.compile :only [eval-in-project]])
+  (:import [java.io File]))
 
 (defn swank
   "Launch swank server for Emacs to connect. Optionally takes PORT and HOST."
@@ -7,7 +8,7 @@
      (eval-in-project project
                       `(do
                          (let [is# ~(:init-script project)]
-                           (when is#
+                           (when (and is# (.exists (File. is#)))
                              (load-file is#)))
                          (require '~'swank.swank)
                            (@(ns-resolve '~'swank.swank '~'start-repl)

--- a/src/leiningen/swank.clj
+++ b/src/leiningen/swank.clj
@@ -1,5 +1,6 @@
 (ns leiningen.swank
-  (:use [leiningen.compile :only [eval-in-project]])
+  (:use [leiningen.compile :only [eval-in-project]]
+        [leiningen.core :only [get-global-init-script]])
   (:import [java.io File]))
 
 (defn swank
@@ -7,13 +8,16 @@
   ([project port host & opts]
      (eval-in-project project
                       `(do
-                         (let [is# ~(:init-script project)]
-                           (when (and is# (.exists (File. is#)))
+                         (let [is# ~(:init-script project)
+                               gis# ~(get-global-init-script)]
+                           (when (not (nil? gis#))
+                             (load-file gis#))
+                           (when (and (not (nil? is#)) (.exists (File. (str is#))))
                              (load-file is#)))
                          (require '~'swank.swank)
-                           (@(ns-resolve '~'swank.swank '~'start-repl)
-                            (Integer. ~port)
-                            ~@(concat (map read-string opts)
-                                      [:host host])))))
+                         (@(ns-resolve '~'swank.swank '~'start-repl)
+                          (Integer. ~port)
+                          ~@(concat (map read-string opts)
+                                    [:host host])))))
   ([project port] (swank project port "localhost"))
   ([project] (swank project 4005)))

--- a/src/swank/clj_contrib/pprint.clj
+++ b/src/swank/clj_contrib/pprint.clj
@@ -1,27 +1,27 @@
 (ns swank.clj-contrib.pprint)
 
 (def #^{:private true} pprint-enabled?
-  (try ;; 1.0, 1.1
-    (.loadClass (clojure.lang.RT/baseLoader)
-                "clojure.contrib.pprint.PrettyWriter")
-    (require '[clojure.contrib.pprint :as pp])
+  (try ;; 1.2+
+    (.getResource (clojure.lang.RT/baseLoader) "clojure/pprint")
+    (require '[clojure.pprint :as pp])
     (defmacro #^{:private true} pretty-pr-code*
       ([code]
          (if pprint-enabled?
            `(binding [pp/*print-suppress-namespaces* true]
-              (pp/with-pprint-dispatch pp/*code-dispatch*
+              (pp/with-pprint-dispatch pp/code-dispatch
                 (pp/write ~code :pretty true :stream nil)))
            `(pr-str ~code))))
     true
     (catch Exception e
-      (try ;; 1.2
-        (.getResource (clojure.lang.RT/baseLoader) "clojure/pprint")
-        (require '[clojure.pprint :as pp])
+      (try ;; 1.0, 1.1
+        (.loadClass (clojure.lang.RT/baseLoader)
+                    "clojure.contrib.pprint.PrettyWriter")
+        (require '[clojure.contrib.pprint :as pp])
         (defmacro #^{:private true} pretty-pr-code*
           ([code]
              (if pprint-enabled?
                `(binding [pp/*print-suppress-namespaces* true]
-                  (pp/with-pprint-dispatch pp/code-dispatch
+                  (pp/with-pprint-dispatch pp/*code-dispatch*
                     (pp/write ~code :pretty true :stream nil)))
                `(pr-str ~code))))
         true

--- a/src/swank/clj_contrib/pprint.clj
+++ b/src/swank/clj_contrib/pprint.clj
@@ -7,12 +7,12 @@
   ;; 1.0, 1.1
   (do
     (.loadClass (clojure.lang.RT/baseLoader) "clojure.contrib.pprint.PrettyWriter")
-    (use 'clojure.contrib.pprint)
+    (require '[clojure.contrib.pprint :as pp])
     (defmacro pretty-pr-code*
       ([code]
          (if pprint-enabled?
            `(binding [*print-suppress-namespaces* true]
-              (with-pprint-dispatch *code-dispatch* (write ~code :pretty true :stream nil)))
+              (pp/with-pprint-dispatch pp/*code-dispatch* (pp/write ~code :pretty true :stream nil)))
            `(pr-str ~code)))
       {:private true})
     true)
@@ -21,7 +21,7 @@
      ;; 1.2
      (do
        (.getResource (clojure.lang.RT/baseLoader) "clojure/pprint")
-       (use 'clojure.pprint)
+       (require '[clojure.pprint :as pp])
        (defmacro pretty-pr-code*
          ([code]
             (if pprint-enabled?

--- a/src/swank/clj_contrib/pprint.clj
+++ b/src/swank/clj_contrib/pprint.clj
@@ -25,6 +25,8 @@
                     (pp/write ~code :pretty true :stream nil)))
                `(pr-str ~code))))
         true
+        ;; if you just don't have contrib, be silent.
+        (catch ClassNotFoundException _)
         (catch Exception e
           (println e))))))
 

--- a/src/swank/clj_contrib/pprint.clj
+++ b/src/swank/clj_contrib/pprint.clj
@@ -4,7 +4,7 @@
  #^{:private true}
  pprint-enabled?
  (try
-  ;; 1.1.0
+  ;; 1.0, 1.1
   (do
     (.loadClass (clojure.lang.RT/baseLoader) "clojure.contrib.pprint.PrettyWriter")
     (use 'clojure.contrib.pprint)
@@ -18,7 +18,7 @@
     true)
   (catch Exception e
     (try
-     ;; 1.2.0
+     ;; 1.2
      (do
        (.getResource (clojure.lang.RT/baseLoader) "clojure/pprint")
        (use 'clojure.pprint)

--- a/src/swank/clj_contrib/pprint.clj
+++ b/src/swank/clj_contrib/pprint.clj
@@ -1,7 +1,7 @@
 (ns swank.clj-contrib.pprint)
 
 (def
- #^{:private true}
+ ^{:private true}
  pprint-enabled?
  (try
   ;; 1.0, 1.1
@@ -11,7 +11,7 @@
     (defmacro pretty-pr-code*
       ([code]
          (if pprint-enabled?
-           `(binding [*print-suppress-namespaces* true]
+           `(binding [pp/*print-suppress-namespaces* true]
               (pp/with-pprint-dispatch pp/*code-dispatch* (pp/write ~code :pretty true :stream nil)))
            `(pr-str ~code)))
       {:private true})
@@ -25,8 +25,8 @@
        (defmacro pretty-pr-code*
          ([code]
             (if pprint-enabled?
-              `(binding [*print-suppress-namespaces* true]
-                 (with-pprint-dispatch code-dispatch (write ~code :pretty true :stream nil)))
+              `(binding [pp/*print-suppress-namespaces* true]
+                 (pp/with-pprint-dispatch pp/code-dispatch (pp/write ~code :pretty true :stream nil)))
               `(pr-str ~code)))
          {:private true})
        true)

--- a/src/swank/clj_contrib/pprint.clj
+++ b/src/swank/clj_contrib/pprint.clj
@@ -1,37 +1,32 @@
 (ns swank.clj-contrib.pprint)
 
-(def
- ^{:private true}
- pprint-enabled?
- (try
-  ;; 1.0, 1.1
-  (do
-    (.loadClass (clojure.lang.RT/baseLoader) "clojure.contrib.pprint.PrettyWriter")
+(def #^{:private true} pprint-enabled?
+  (try ;; 1.0, 1.1
+    (.loadClass (clojure.lang.RT/baseLoader)
+                "clojure.contrib.pprint.PrettyWriter")
     (require '[clojure.contrib.pprint :as pp])
-    (defmacro pretty-pr-code*
+    (defmacro #^{:private true} pretty-pr-code*
       ([code]
          (if pprint-enabled?
            `(binding [pp/*print-suppress-namespaces* true]
-              (pp/with-pprint-dispatch pp/*code-dispatch* (pp/write ~code :pretty true :stream nil)))
-           `(pr-str ~code)))
-      {:private true})
-    true)
-  (catch Exception e
-    (try
-     ;; 1.2
-     (do
-       (.getResource (clojure.lang.RT/baseLoader) "clojure/pprint")
-       (require '[clojure.pprint :as pp])
-       (defmacro pretty-pr-code*
-         ([code]
-            (if pprint-enabled?
-              `(binding [pp/*print-suppress-namespaces* true]
-                 (pp/with-pprint-dispatch pp/code-dispatch (pp/write ~code :pretty true :stream nil)))
-              `(pr-str ~code)))
-         {:private true})
-       true)
-     (catch Exception e
-       (println e))))))
+              (pp/with-pprint-dispatch pp/*code-dispatch*
+                (pp/write ~code :pretty true :stream nil)))
+           `(pr-str ~code))))
+    true
+    (catch Exception e
+      (try ;; 1.2
+        (.getResource (clojure.lang.RT/baseLoader) "clojure/pprint")
+        (require '[clojure.pprint :as pp])
+        (defmacro #^{:private true} pretty-pr-code*
+          ([code]
+             (if pprint-enabled?
+               `(binding [pp/*print-suppress-namespaces* true]
+                  (pp/with-pprint-dispatch pp/code-dispatch
+                    (pp/write ~code :pretty true :stream nil)))
+               `(pr-str ~code))))
+        true
+        (catch Exception e
+          (println e))))))
 
 (defn pretty-pr-code [code]
   (pretty-pr-code* code))

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -469,8 +469,8 @@ that symbols accessible in the current namespace go first."
 
 (defslimefn frame-catch-tags-for-emacs [n] nil)
 (defslimefn frame-locals-for-emacs [n]
-  (if (and (zero? n) *current-env*)
-    (locals-for-emacs (local-non-functions *current-env*))))
+  (if (and (zero? n) (seq *current-env*))
+    (locals-for-emacs *current-env*)))
 
 (defslimefn frame-locals-and-catch-tags [n]
   (list (frame-locals-for-emacs n)

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -181,11 +181,11 @@
 
 (defn- describe-symbol* [symbol-name]
   (with-emacs-package
-    (if-let [v (try
-                 (ns-resolve (maybe-ns *current-package*) (symbol symbol-name))
+    (let [v (try (ns-resolve (maybe-ns *current-package*) (symbol symbol-name))
                  (catch ClassNotFoundException e nil))]
-      (describe-to-string v)
-      (str "Unknown symbol " symbol-name))))
+      (if (var? v)
+        (describe-to-string v)
+        (str "Unknown symbol " symbol-name)))))
 
 (defslimefn describe-symbol [symbol-name]
   (describe-symbol* symbol-name))

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -209,7 +209,7 @@
 
 (defn- describe-to-string [var]
   (with-out-str
-    (print-doc var)))
+    (print-doc (meta var))))
 
 (defn- describe-symbol* [symbol-name]
   (with-emacs-package

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -495,7 +495,7 @@ that symbols accessible in the current namespace go first."
 (defn locals-for-emacs [m]
   (sort-by second
            (map #(list :name (name (first %)) :id 0
-                       :value (str (second %))) m)))
+                       :value (pr-str (second %))) m)))
 
 (defslimefn frame-catch-tags-for-emacs [n] nil)
 (defslimefn frame-locals-for-emacs [n]

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -192,11 +192,8 @@
 (defn- describe-symbol* [symbol-name]
   (with-emacs-package
     (if-let [v (maybe-resolve-sym symbol-name)]
-      (describe-to-string v)
-      (if-let [ns (maybe-resolve-ns symbol-name)]
-        (str (ns-name ns) "\nnamespace containing:"
-             (apply str (map #(str "\n  " %) (keys (ns-publics (find-ns 'clojure.xml))))))
-        (str "Unknown symbol " symbol-name)))))
+      (if-not (class? v)
+        (describe-to-string v)))))
 
 (defslimefn describe-symbol [symbol-name]
   (describe-symbol* symbol-name))
@@ -561,4 +558,3 @@ corresponding attribute values per thread."
 
 (defslimefn quit-thread-browser []
   (reset! thread-list []))
-

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -78,10 +78,10 @@
 
 (defslimefn eval-and-grab-output [string]
   (with-emacs-package
-    (with-local-vars [retval nil]
+    (let [retval (promise)]
       (list (with-out-str
-              (var-set retval (pr-str (first (eval-region string)))))
-            (var-get retval)))))
+              (deliver retval (pr-str (first (eval-region string)))))
+            @retval))))
 
 (defslimefn pprint-eval [string]
   (with-emacs-package

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -20,13 +20,13 @@
                                      :version ~(clojure-version))
          :package (:name ~(name (ns-name *ns*))
                          :prompt ~(name (ns-name *ns*)))
-         :version ~(deref *protocol-version*)))
+         :version ~(deref protocol-version)))
 
 (defslimefn quit-lisp []
   (System/exit 0))
 
 (defslimefn toggle-debug-on-swank-error []
-  (alter-var-root #'swank.core/*debug-swank-clojure* not))
+  (alter-var-root #'swank.core/debug-swank-clojure not))
 
 ;;;; Evaluation
 
@@ -103,10 +103,10 @@
 
 ;;;; Compiler / Execution
 
-(def *compiler-exception-location-re* #"Exception:.*\(([^:]+):([0-9]+)\)")
+(def compiler-exception-location-re #"Exception:.*\(([^:]+):([0-9]+)\)")
 (defn- guess-compiler-exception-location [#^Throwable t]
   (when (instance? clojure.lang.Compiler$CompilerException t)
-    (let [[match file line] (re-find *compiler-exception-location-re* (str t))]
+    (let [[match file line] (re-find compiler-exception-location-re (str t))]
       (when (and file line)
         `(:location (:file ~file) (:line ~(Integer/parseInt line)) nil)))))
 
@@ -463,7 +463,7 @@ that symbols accessible in the current namespace go first."
               :not-implemented)))
 
 (defslimefn throw-to-toplevel []
-  (throw *debug-quit-exception*))
+  (throw debug-quit-exception))
 
 (defn invoke-restart [restart]
   ((nth restart 2)))

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -322,7 +322,7 @@ that symbols accessible in the current namespace go first."
 
 (defonce traced-fn-map {})
 
-(def ^:dynamic *trace-level* 0)
+(def #^{:dynamic true} *trace-level* 0)
 
 (defn- indent [num]
   (dotimes [x (+ 1 num)]

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -322,7 +322,7 @@ that symbols accessible in the current namespace go first."
 
 (defonce traced-fn-map {})
 
-(def *trace-level* 0)
+(def ^:dynamic *trace-level* 0)
 
 (defn- indent [num]
   (dotimes [x (+ 1 num)]

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -268,8 +268,7 @@ that symbols accessible in the current namespace go first."
      (apropos-list-for-emacs name external-only? case-sensitive? nil))
   ([name external-only? case-sensitive? package]
      (let [package (when package
-                     (or (find-ns (symbol package))
-                         'user))]
+                     (maybe-ns package))]
        (map briefly-describe-symbol-for-emacs
             (sort present-symbol-before
                   (apropos-symbols name external-only? case-sensitive?

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -70,10 +70,9 @@
     (with-package-tracking
       (let [[value last-form] (eval-region form)]
         (when (and last-form (not (one-of? last-form '*1 '*2 '*3 '*e)))
-          ;; (set! *3 *2)
-          ;; (set! *2 *1)
-          ;; (set! *1 value)
-          )
+          (set! *3 *2)
+          (set! *2 *1)
+          (set! *1 value))
         (send-repl-results-to-emacs value)))))
 
 (defslimefn eval-and-grab-output [string]

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -185,6 +185,28 @@
     (or ((ns-aliases (maybe-ns *current-package*)) sym)
         (find-ns sym))))
 
+(defn- print-doc [m]
+  (println "-------------------------")
+  (println (str (when-let [ns (:ns m)] (str (ns-name ns) "/")) (:name m)))
+  (cond
+    (:forms m) (doseq [f (:forms m)]
+                 (print "  ")
+                 (prn f))
+    (:arglists m) (prn (:arglists m)))
+  (if (:special-form m)
+    (do
+      (println "Special Form")
+      (println " " (:doc m)) 
+      (if (contains? m :url)
+        (when (:url m)
+          (println (str "\n  Please see http://clojure.org/" (:url m))))
+        (println (str "\n  Please see http://clojure.org/special_forms#"
+                      (:name m)))))
+    (do
+      (when (:macro m)
+        (println "Macro")) 
+      (println " " (:doc m)))))
+
 (defn- describe-to-string [var]
   (with-out-str
     (print-doc var)))

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -181,7 +181,9 @@
 
 (defn- describe-symbol* [symbol-name]
   (with-emacs-package
-    (if-let [v (ns-resolve (maybe-ns *current-package*) (symbol symbol-name))]
+    (if-let [v (try
+                 (ns-resolve (maybe-ns *current-package*) (symbol symbol-name))
+                 (catch ClassNotFoundException e nil))]
       (describe-to-string v)
       (str "Unknown symbol " symbol-name))))
 

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -300,12 +300,20 @@ that symbols accessible in the current namespace go first."
 
 (defonce traced-fn-map {})
 
+(def *trace-level* 0)
+
+(defn- indent [num]
+  (dotimes [x (+ 1 num)]
+    (print "  ")))
+
 (defn- trace-fn-call [sym f args]
   (let [fname (symbol (str (.name (.ns sym)) "/" (.sym sym)))]
-    (println (str "Calling")
+    (indent *trace-level*)
+    (println (str *trace-level* ":")
              (apply str (take 240 (pr-str (when fname (cons fname args)) ))))
-    (let [result (apply f args)]
-      (println (str fname " returned " (apply str (take 240 (pr-str result)))))
+    (let [result (binding [*trace-level* (+ *trace-level* 1)] (apply f args))]
+      (indent *trace-level*)
+      (println (str *trace-level* ": " fname " returned " (apply str (take 240 (pr-str result)))))
       result)))
 
 (defslimefn swank-toggle-trace [fname]

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -467,7 +467,9 @@ that symbols accessible in the current namespace go first."
 (defslimefn buffer-first-change [file-name] nil)
 
 (defn locals-for-emacs [m]
-  (map #(list :name (name (first %)) :id 0 :value (str (second %))) m))
+  (sort-by second
+           (map #(list :name (name (first %)) :id 0
+                       :value (str (second %))) m)))
 
 (defslimefn frame-catch-tags-for-emacs [n] nil)
 (defslimefn frame-locals-for-emacs [n]

--- a/src/swank/commands/basic.clj
+++ b/src/swank/commands/basic.clj
@@ -70,9 +70,10 @@
     (with-package-tracking
       (let [[value last-form] (eval-region form)]
         (when (and last-form (not (one-of? last-form '*1 '*2 '*3 '*e)))
-          (set! *3 *2)
-          (set! *2 *1)
-          (set! *1 value))
+          ;; (set! *3 *2)
+          ;; (set! *2 *1)
+          ;; (set! *1 value)
+          )
         (send-repl-results-to-emacs value)))))
 
 (defslimefn eval-and-grab-output [string]

--- a/src/swank/commands/completion.clj
+++ b/src/swank/commands/completion.clj
@@ -48,9 +48,9 @@
   ([#^Class class]
      (concat (map member-name (static-methods class))
 	     (map member-name (static-fields class)))))
-     
 
-(defn potintial-classes-on-path
+
+(defn potential-classes-on-path
   "Returns a list of Java class and Clojure package names found on the current
   classpath. To minimize noise, list is nil unless a '.' is present in the search
   string, and nested classes are only shown if a '$' is present."
@@ -93,7 +93,7 @@
   (try
    (let [[sym-ns sym-name] (symbol-name-parts symbol-string)
 		 potential         (concat (potential-completions (when sym-ns (symbol sym-ns)) (ns-name (maybe-ns package)))
-								   (potintial-classes-on-path symbol-string))
+								   (potential-classes-on-path symbol-string))
          matches           (seq (sort (filter #(.startsWith #^String % symbol-string) potential)))]
      (list matches
            (if matches

--- a/src/swank/commands/completion.clj
+++ b/src/swank/commands/completion.clj
@@ -50,7 +50,7 @@
 	     (map member-name (static-fields class)))))
      
 
-(defn potiential-classes-on-path
+(defn potintial-classes-on-path
   "Returns a list of Java class and Clojure package names found on the current
   classpath. To minimize noise, list is nil unless a '.' is present in the search
   string, and nested classes are only shown if a '$' is present."
@@ -93,7 +93,7 @@
   (try
    (let [[sym-ns sym-name] (symbol-name-parts symbol-string)
 		 potential         (concat (potential-completions (when sym-ns (symbol sym-ns)) (ns-name (maybe-ns package)))
-								   (potiential-classes-on-path symbol-string))
+								   (potintial-classes-on-path symbol-string))
          matches           (seq (sort (filter #(.startsWith #^String % symbol-string) potential)))]
      (list matches
            (if matches

--- a/src/swank/commands/contrib/swank_arglists.clj
+++ b/src/swank/commands/contrib/swank_arglists.clj
@@ -3,6 +3,43 @@
 
 ((slime-fn 'swank-require) :swank-c-p-c)
 
+(defn position-in-params? [params pos]
+  (or (some #(= '& %) params)
+      (<= pos (count params))))
+
+;; (position-in-params? '[x y] 2)
+
+(defn highlight-position [params pos]
+  (if (<= pos (count (take-while #(not= % '&) params)))
+    (into [] (concat (take (dec pos) params)
+                     '(===>)
+                     (list (nth params (dec pos)))
+                     '(<===)
+                     (drop pos params)))
+    (if (some #(= % '&) params)
+      (into [] (concat (take-while #(not= % '&) params)
+                       '(===>)
+                       '(&)
+                       (list (last params))
+                       '(<===))))))
+
+;; (highlight-position '[x y] 1)
+
+(defn highlight-param-lists [params-list pos]
+  (loop [checked []
+         current (first params-list)
+         remaining (rest params-list)]
+    (if (position-in-params? current pos)
+      (concat checked
+              [(highlight-position current pos)]
+              remaining)
+      (when (seq remaining)
+        (recur (conj checked current)
+               (first remaining)
+               (rest remaining))))))
+
+;; (highlight-param-lists '([fname & body]) 1)
+
 (defslimefn arglist-for-echo-area [raw-specs & options]
   (let [{:keys [arg-indices
                 print-right-margin
@@ -11,7 +48,13 @@
     (if (and raw-specs
              (seq? raw-specs)
              (seq? (first raw-specs)))
-      ((slime-fn 'operator-arglist) (ffirst raw-specs) *current-package*)
+      (let [result ((slime-fn 'operator-arglist) (ffirst raw-specs) *current-package*)
+            pos (first (second options))
+            cmd (ffirst raw-specs)]
+        (str cmd ": "
+             (if (or (zero? pos) (nil? result))
+               nil
+               (apply list (highlight-param-lists (read-string result) pos)))))
       nil)))
 
 (defslimefn variable-desc-for-echo-area [variable-name]

--- a/src/swank/commands/contrib/swank_arglists.clj
+++ b/src/swank/commands/contrib/swank_arglists.clj
@@ -39,9 +39,9 @@
            current (first arglists)
            remaining (rest arglists)]
       (if (position-in-arglist? current pos)
-        (into '() (concat checked
-                          [(highlight-position current pos)]
-                          remaining))
+        (apply list (concat checked
+                            [(highlight-position current pos)]
+                            remaining))
         (when (seq remaining)
           (recur (conj checked current)
                  (first remaining)

--- a/src/swank/commands/contrib/swank_arglists.clj
+++ b/src/swank/commands/contrib/swank_arglists.clj
@@ -52,8 +52,22 @@
 
 ;;(defmacro dbg[x] `(let [x# ~x] (println '~x "->" x#) x#))
 
-(defn arglists-for-fname [fname]
+(defn defnk-arglists? [arglists]
+  (and (not (nil? arglists ))
+       (not (vector? (first (read-string arglists))))))
+
+(defn fix-defnk-arglists [arglists]
+  (str (list (into [] (read-string arglists)))))
+
+(defn arglists-for-fname-lookup [fname]
   ((slime-fn 'operator-arglist) fname *current-package*))
+
+(defn arglists-for-fname [fname]
+  (let [arglists (arglists-for-fname-lookup fname)]
+    ;; defnk's arglists format is (a b) instead of ([a b])
+    (if (defnk-arglists? arglists)
+      (fix-defnk-arglists arglists)
+      arglists)))
 
 (defn message-format [cmd arglists pos]
   (str (when cmd (str cmd ": "))

--- a/src/swank/commands/contrib/swank_arglists.clj
+++ b/src/swank/commands/contrib/swank_arglists.clj
@@ -3,59 +3,99 @@
 
 ((slime-fn 'swank-require) :swank-c-p-c)
 
-(defn position-in-params? [params pos]
-  (or (some #(= '& %) params)
-      (<= pos (count params))))
+;;; pos starts at 1 bc 0 is function name
+(defn position-in-arglist? [arglist pos]
+  (or (some #(= '& %) arglist)
+      (<= pos (count arglist))))
 
-;; (position-in-params? '[x y] 2)
+;; (position-in-arglist? '[x y] 2)
+;; => true
 
-(defn highlight-position [params pos]
-  (if (<= pos (count (take-while #(not= % '&) params)))
-    (into [] (concat (take (dec pos) params)
-                     '(===>)
-                     (list (nth params (dec pos)))
-                     '(<===)
-                     (drop pos params)))
-    (if (some #(= % '&) params)
-      (into [] (concat (take-while #(not= % '&) params)
-                       '(===>)
-                       '(&)
-                       (list (last params))
-                       '(<===))))))
+(defn highlight-position [arglist pos]
+  (if (zero? pos)
+    arglist
+    ;; i.e. not rest args
+    (let [num-normal-args (count (take-while #(not= % '&) arglist))]
+      (if (<= pos num-normal-args)
+        (into [] (concat (take (dec pos) arglist)
+                         '(===>)
+                         (list (nth arglist (dec pos)))
+                         '(<===)
+                         (drop pos arglist)))
+        (let [rest-arg? (some #(= % '&) arglist)]
+          (if rest-arg?
+            (into [] (concat (take-while #(not= % '&) arglist)
+                             '(===>)
+                             '(&)
+                             (list (last arglist))
+                             '(<===)))))))))
 
-;; (highlight-position '[x y] 1)
+;; (highlight-position '[x y] 0)
+;; => [===> x <=== y]
 
-(defn highlight-param-lists [params-list pos]
-  (loop [checked []
-         current (first params-list)
-         remaining (rest params-list)]
-    (if (position-in-params? current pos)
-      (concat checked
-              [(highlight-position current pos)]
-              remaining)
-      (when (seq remaining)
-        (recur (conj checked current)
-               (first remaining)
-               (rest remaining))))))
+(defn highlight-arglists [arglists pos]
+  (let [arglists (read-string arglists)]
+    (loop [checked []
+           current (first arglists)
+           remaining (rest arglists)]
+      (if (position-in-arglist? current pos)
+        (into '() (concat checked
+                          [(highlight-position current pos)]
+                          remaining))
+        (when (seq remaining)
+          (recur (conj checked current)
+                 (first remaining)
+                 (rest remaining)))))))
 
-;; (highlight-param-lists '([fname & body]) 1)
+;; (highlight-arglists "([x] [x & more])" 1)
+;; => ([===> x <===] [x & more])
+
+(defmacro dbg[x] `(let [x# ~x] (println '~x "->" x#) x#))
+
+(defn arglists-for-fname [fname]
+  ((slime-fn 'operator-arglist) fname *current-package*))
+
+(defn message-format [cmd arglists pos]
+  (str (when cmd (str cmd ": "))
+       (when arglists
+         (if pos
+           (highlight-arglists arglists pos)
+           arglists))))
+
+(defn handle-apply [raw-specs pos]
+  (let [fname (second (first raw-specs))]
+    (message-format fname (arglists-for-fname fname) (dec pos))))
 
 (defslimefn arglist-for-echo-area [raw-specs & options]
   (let [{:keys [arg-indices
                 print-right-margin
                 print-lines]} (apply hash-map options)]
-    ;; Yeah, I'm lazy -- I'll flesh this out later
-    (if (and raw-specs
-             (seq? raw-specs)
-             (seq? (first raw-specs)))
-      (let [result ((slime-fn 'operator-arglist) (ffirst raw-specs) *current-package*)
-            pos (first (second options))
-            cmd (ffirst raw-specs)]
-        (str cmd ": "
-             (if (or (zero? pos) (nil? result))
-               nil
-               (apply list (highlight-param-lists (read-string result) pos)))))
-      nil)))
+    (if-not (and raw-specs
+                 (seq? raw-specs)
+                 (seq? (first raw-specs)))
+      nil ;; problem?
+      (let [pos (first (second options))
+            top-level? (= 1 (count raw-specs))
+            parent-pos (when-not top-level?
+                         (second (second options)))
+            fname (ffirst raw-specs)
+            parent-fname (when-not top-level?
+                           (first (second raw-specs)))
+            arglists (arglists-for-fname fname)
+            inside-binding? (and (not top-level?)
+                                 (#{"let" "binding" "doseq" "for" "loop"}
+                                  parent-fname)
+                                 (= 1 parent-pos))]
+        (dbg raw-specs)
+        (dbg options)
+        (cond
+         ;; display arglists for function being applied unless on top of apply
+         (and (= fname "apply") (not= pos 0)) (handle-apply raw-specs pos)              
+         ;; highlight binding inside binding forms unless >1 level deep
+         inside-binding? (message-format parent-fname
+                                         (arglists-for-fname parent-fname)
+                                         1)
+         :else  (message-format fname arglists pos))))))
 
 (defslimefn variable-desc-for-echo-area [variable-name]
   (with-emacs-package

--- a/src/swank/commands/contrib/swank_arglists.clj
+++ b/src/swank/commands/contrib/swank_arglists.clj
@@ -50,7 +50,7 @@
 ;; (highlight-arglists "([x] [x & more])" 1)
 ;; => ([===> x <===] [x & more])
 
-(defmacro dbg[x] `(let [x# ~x] (println '~x "->" x#) x#))
+;;(defmacro dbg[x] `(let [x# ~x] (println '~x "->" x#) x#))
 
 (defn arglists-for-fname [fname]
   ((slime-fn 'operator-arglist) fname *current-package*))
@@ -86,8 +86,8 @@
                                  (#{"let" "binding" "doseq" "for" "loop"}
                                   parent-fname)
                                  (= 1 parent-pos))]
-        (dbg raw-specs)
-        (dbg options)
+;;         (dbg raw-specs)
+;;         (dbg options)
         (cond
          ;; display arglists for function being applied unless on top of apply
          (and (= fname "apply") (not= pos 0)) (handle-apply raw-specs pos)              

--- a/src/swank/commands/contrib/swank_c_p_c.clj
+++ b/src/swank/commands/contrib/swank_c_p_c.clj
@@ -7,7 +7,8 @@
 (defslimefn completions [symbol-string package]
   (try
    (let [[sym-ns sym-name] (symbol-name-parts symbol-string)
-         potential         (potential-completions (when sym-ns (symbol sym-ns)) (ns-name (maybe-ns package)))
+         potential         (potential-completions (concat (when sym-ns (symbol sym-ns)) (ns-name (maybe-ns package))
+                                                          (potiential-classes-on-path symbol-string)))
          matches           (seq (sort (filter #(split-compound-prefix-match? symbol-string %) potential)))]
      (list matches
            (if matches

--- a/src/swank/commands/contrib/swank_c_p_c.clj
+++ b/src/swank/commands/contrib/swank_c_p_c.clj
@@ -7,8 +7,11 @@
 (defslimefn completions [symbol-string package]
   (try
    (let [[sym-ns sym-name] (symbol-name-parts symbol-string)
-         potential         (potential-completions (concat (when sym-ns (symbol sym-ns)) (ns-name (maybe-ns package))
-                                                          (potiential-classes-on-path symbol-string)))
+         potential         (concat
+			    (potential-completions
+			     (when sym-ns (symbol sym-ns))
+			     (ns-name (maybe-ns package)))
+			    (potintial-classes-on-path symbol-string))
          matches           (seq (sort (filter #(split-compound-prefix-match? symbol-string %) potential)))]
      (list matches
            (if matches

--- a/src/swank/commands/contrib/swank_c_p_c.clj
+++ b/src/swank/commands/contrib/swank_c_p_c.clj
@@ -11,7 +11,7 @@
 			    (potential-completions
 			     (when sym-ns (symbol sym-ns))
 			     (ns-name (maybe-ns package)))
-			    (potintial-classes-on-path symbol-string))
+			    (potential-classes-on-path symbol-string))
          matches           (seq (sort (filter #(split-compound-prefix-match? symbol-string %) potential)))]
      (list matches
            (if matches

--- a/src/swank/commands/contrib/swank_fuzzy.clj
+++ b/src/swank/commands/contrib/swank_fuzzy.clj
@@ -12,7 +12,7 @@
   (:use (swank util core commands))
   (:use (swank.util clojure)))
 
-(def ^:dynamic *fuzzy-recursion-soft-limit* 30)
+(def #^{:dynamic true} *fuzzy-recursion-soft-limit* 30)
 (defn- compute-most-completions [short full]
   (let [collect-chunk (fn [[pcur [[pa va] ys]] [pb vb]]
                         (let [xs (if (= (dec pb) pcur)

--- a/src/swank/commands/contrib/swank_fuzzy.clj
+++ b/src/swank/commands/contrib/swank_fuzzy.clj
@@ -12,7 +12,7 @@
   (:use (swank util core commands))
   (:use (swank.util clojure)))
 
-(def *fuzzy-recursion-soft-limit* 30)
+(def ^:dynamic *fuzzy-recursion-soft-limit* 30)
 (defn- compute-most-completions [short full]
   (let [collect-chunk (fn [[pcur [[pa va] ys]] [pb vb]]
                         (let [xs (if (= (dec pb) pcur)
@@ -44,9 +44,9 @@
                  (recur short (rest full) (inc pos) chunk seed false)))]
     (map reverse (step short full 0 [] () false))))
 
-(def *fuzzy-completion-symbol-prefixes* "*+-%&?<")
-(def *fuzzy-completion-word-separators* "-/.")
-(def *fuzzy-completion-symbol-suffixes* "*+->?!")
+(def fuzzy-completion-symbol-prefixes "*+-%&?<")
+(def fuzzy-completion-word-separators "-/.")
+(def fuzzy-completion-symbol-suffixes "*+->?!")
 (defn- score-completion [completion short full]
   (let [find1
         (fn [c s]
@@ -55,13 +55,13 @@
         after-prefix?
         (fn [pos]
           (and (= pos 1)
-               (find1 (nth full 0) *fuzzy-completion-symbol-prefixes*)))
+               (find1 (nth full 0) fuzzy-completion-symbol-prefixes)))
         word-separator?
         (fn [pos]
-          (find1 (nth full pos) *fuzzy-completion-word-separators*))
+          (find1 (nth full pos) fuzzy-completion-word-separators))
         after-word-separator?
         (fn [pos]
-          (find1 (nth full (dec pos)) *fuzzy-completion-word-separators*))
+          (find1 (nth full (dec pos)) fuzzy-completion-word-separators))
         at-end?
         (fn [pos]
           (= pos (dec (count full))))
@@ -69,7 +69,7 @@
         (fn [pos]
           (and (= pos (- (count full) 2))
                (find1 (nth full (dec (count full)))
-                      *fuzzy-completion-symbol-suffixes*)))]
+                      fuzzy-completion-symbol-suffixes)))]
     (letfn [(score-or-percentage-of-previous
              [base-score pos chunk-pos]
              (if (zero? chunk-pos)

--- a/src/swank/commands/indent.clj
+++ b/src/swank/commands/indent.clj
@@ -97,4 +97,4 @@
       *current-connection*
       (need-full-indentation-update? *current-connection*))))
 
-(add-hook *pre-reply-hook* #'sync-indentation-to-emacs)
+(add-hook pre-reply-hook #'sync-indentation-to-emacs)

--- a/src/swank/commands/inspector.clj
+++ b/src/swank/commands/inspector.clj
@@ -181,7 +181,7 @@
      (mapcat (fn [m]
                `("  " (:value ~m) (:newline))) meths))))
 
-(defmethod emacs-inspect :aref [#^ARef obj]
+(defmethod emacs-inspect :aref [#^clojure.lang.ARef obj]
   `("Type: " (:value ~(class obj)) (:newline)
     "Value: " (:value ~(deref obj)) (:newline)))
 

--- a/src/swank/commands/inspector.clj
+++ b/src/swank/commands/inspector.clj
@@ -266,7 +266,7 @@
 
 (defslimefn inspect-frame-var [frame index]
   (if (and (zero? frame) *current-env*)
-    (let [locals (local-non-functions *current-env*)
+    (let [locals *current-env*
           object (locals (nth (keys locals) index))]
       (with-emacs-package
         (reset-inspector)

--- a/src/swank/core.clj
+++ b/src/swank/core.clj
@@ -67,9 +67,6 @@
       (let [symbols (keys &env)]
         (zipmap (map (fn [sym] `(quote ~sym)) symbols) symbols)))))
 
-(defn local-non-functions [m]
-  (select-keys m  (filter #(or (coll? (m %)) (not (ifn? (m %)))) (keys m))))
-
 ;; Handle Evaluation
 (defn send-to-emacs
     "Sends a message (msg) to emacs."
@@ -83,11 +80,10 @@
   "Evals a form with given locals. The locals should be a map of symbols to
 values."
   [form]
-  (let [m (local-non-functions *current-env*)]
-    (if (first m)
-      `(let ~(vec (mapcat #(list % (m %)) (keys m)))
-         ~form)
-      form)))
+  (if (seq *current-env*)
+    `(let ~(vec (mapcat #(list % `(*current-env* '~%)) (keys *current-env*)))
+       ~form)
+    form))
 
 (defn eval-in-emacs-package [form]
   (with-emacs-package

--- a/src/swank/core.clj
+++ b/src/swank/core.clj
@@ -270,7 +270,7 @@ values."
 
       :else
       (do
-        ;; (set! *e t)
+        (set! *e t)
         (try
          (sldb-debug
           nil

--- a/src/swank/core.clj
+++ b/src/swank/core.clj
@@ -9,15 +9,17 @@
 (defonce protocol-version (atom "20100404"))
 
 ;; Emacs packages
-(def ^:dynamic *current-package*)
+(def #^{:dynamic true} *current-package*)
 
 ;; current emacs eval id
-(def ^:dynamic *pending-continuations* '())
+(def #^{:dynamic true} *pending-continuations* '())
 
 (def sldb-stepping-p nil)
 (def sldb-initial-frames 10)
-(def ^:dynamic #^{:doc "The current level of recursive debugging."} *sldb-level* 0)
-(def ^:dynamic #^{:doc "The current restarts."} *sldb-restarts* 0)
+(def #^{:dynamic true} #^{:doc "The current level of recursive debugging."}
+  *sldb-level* 0)
+(def #^{:dynamic true} #^{:doc "The current restarts."}
+  *sldb-restarts* 0)
 
 (def #^{:doc "Include swank-clojure thread in stack trace for debugger."}
      debug-swank-clojure false)
@@ -54,10 +56,10 @@
 (defonce debug-continue-exception (Exception. "Debug continue"))
 (defonce debug-abort-exception (Exception. "Debug abort"))
 
-(def ^:dynamic #^Throwable *current-exception* nil)
+(def #^{:dynamic true} #^Throwable *current-exception* nil)
 
 ;; Local environment
-(def ^:dynamic *current-env* nil)
+(def #^{:dynamic true} *current-env* nil)
 
 (let [&env :unavailable]
   (defmacro local-bindings

--- a/src/swank/core.clj
+++ b/src/swank/core.clj
@@ -6,23 +6,23 @@
   (:require (swank.util.concurrent [mbox :as mb])))
 
 ;; Protocol version
-(defonce *protocol-version* (atom "20100404"))
+(defonce protocol-version (atom "20100404"))
 
 ;; Emacs packages
-(def *current-package*)
+(def ^:dynamic *current-package*)
 
 ;; current emacs eval id
-(def *pending-continuations* '())
+(def ^:dynamic *pending-continuations* '())
 
-(def *sldb-stepping-p* nil)
-(def *sldb-initial-frames* 10)
-(def #^{:doc "The current level of recursive debugging."} *sldb-level* 0)
-(def #^{:doc "The current restarts."} *sldb-restarts* 0)
+(def sldb-stepping-p nil)
+(def sldb-initial-frames 10)
+(def ^:dynamic #^{:doc "The current level of recursive debugging."} *sldb-level* 0)
+(def ^:dynamic #^{:doc "The current restarts."} *sldb-restarts* 0)
 
 (def #^{:doc "Include swank-clojure thread in stack trace for debugger."}
-     *debug-swank-clojure* false)
+     debug-swank-clojure false)
 
-(defonce *active-threads* (ref ()))
+(defonce active-threads (ref ()))
 
 (defn maybe-ns [package]
   (cond
@@ -50,14 +50,14 @@
      ~@body))
 
 ;; Exceptions for debugging
-(defonce *debug-quit-exception* (Exception. "Debug quit"))
-(defonce *debug-continue-exception* (Exception. "Debug continue"))
-(defonce *debug-abort-exception* (Exception. "Debug abort"))
+(defonce debug-quit-exception (Exception. "Debug quit"))
+(defonce debug-continue-exception (Exception. "Debug continue"))
+(defonce debug-abort-exception (Exception. "Debug abort"))
 
-(def #^Throwable *current-exception* nil)
+(def ^:dynamic #^Throwable *current-exception* nil)
 
 ;; Local environment
-(def *current-env* nil)
+(def ^:dynamic *current-env* nil)
 
 (let [&env :unavailable]
   (defmacro local-bindings
@@ -107,13 +107,13 @@ values."
               (exception-causes cause)))))
 
 (defn- debug-quit-exception? [t]
-  (some #(identical? *debug-quit-exception* %) (exception-causes t)))
+  (some #(identical? debug-quit-exception %) (exception-causes t)))
 
 (defn- debug-continue-exception? [t]
-  (some #(identical? *debug-continue-exception* %) (exception-causes t)))
+  (some #(identical? debug-continue-exception %) (exception-causes t)))
 
 (defn- debug-abort-exception? [t]
-  (some #(identical? *debug-abort-exception* %) (exception-causes t)))
+  (some #(identical? debug-abort-exception %) (exception-causes t)))
 
 (defn exception-stacktrace [t]
   (map #(list %1 %2 '(:restartable nil))
@@ -157,18 +157,18 @@ values."
 
 (defn calculate-restarts [thrown]
   (let [restarts [(make-restart :quit "QUIT" "Quit to the SLIME top level"
-                               (fn [] (throw *debug-quit-exception*)))]
+                               (fn [] (throw debug-quit-exception)))]
         restarts (add-restart-if
                   (pos? *sldb-level*)
                   restarts
                   :abort "ABORT" (str "ABORT to SLIME level " (dec *sldb-level*))
-                  (fn [] (throw *debug-abort-exception*)))
+                  (fn [] (throw debug-abort-exception)))
         restarts (add-restart-if
                   (and (.getMessage thrown)
                        (.contains (.getMessage thrown) "BREAK"))
                   restarts
                   :continue "CONTINUE" (str "Continue from breakpoint")
-                  (fn [] (throw *debug-continue-exception*)))
+                  (fn [] (throw debug-continue-exception)))
         restarts (add-cause-restarts restarts thrown)]
     (into (array-map) restarts)))
 
@@ -192,14 +192,14 @@ values."
   (try
    (send-to-emacs
     (list* :debug (current-thread) level
-           (build-debugger-info-for-emacs 0 *sldb-initial-frames*)))
+           (build-debugger-info-for-emacs 0 sldb-initial-frames)))
    ([] (continuously
         (do
           (send-to-emacs `(:debug-activate ~(current-thread) ~level nil))
           (eval-from-control))))
    (catch Throwable t
      (send-to-emacs
-      `(:debug-return ~(current-thread) ~*sldb-level* ~*sldb-stepping-p*))
+      `(:debug-return ~(current-thread) ~*sldb-level* ~sldb-stepping-p))
      (if-not (debug-continue-exception? t)
        (throw t)))))
 
@@ -235,7 +235,7 @@ values."
      (if-let [f (slime-fn (first form))]
        (let [form (cons f (rest form))
              result (doall-seq (eval-in-emacs-package form))]
-         (run-hook *pre-reply-hook*)
+         (run-hook pre-reply-hook)
          (send-to-emacs `(:return ~(thread-name (current-thread))
                                   (:ok ~result) ~id)))
        ;; swank function not defined, abort
@@ -259,7 +259,7 @@ values."
       (do
         (send-to-emacs `(:return ~(thread-name (current-thread)) (:abort) ~id))
         (if-not (zero? *sldb-level*)
-          (throw *debug-abort-exception*)))
+          (throw debug-abort-exception)))
 
       (debug-continue-exception? t)
       (do
@@ -272,18 +272,18 @@ values."
         (try
          (sldb-debug
           nil
-          (if *debug-swank-clojure* t (.getCause t))
+          (if debug-swank-clojure t (.getCause t))
           id)
          ;; reply with abort
          (finally (send-to-emacs `(:return ~(thread-name (current-thread)) (:abort) ~id)))))))))
 
 (defn- add-active-thread [thread]
   (dosync
-   (commute *active-threads* conj thread)))
+   (commute active-threads conj thread)))
 
 (defn- remove-active-thread [thread]
   (dosync
-   (commute *active-threads* (fn [threads] (remove #(= % thread) threads)))))
+   (commute active-threads (fn [threads] (remove #(= % thread) threads)))))
 
 (defn spawn-worker-thread
   "Spawn an thread that blocks for a single command from the control
@@ -369,8 +369,8 @@ values."
          (let [[thread & args] args]
            (dosync
             (cond
-             (and (true? thread) (seq @*active-threads*))
-             (.stop #^Thread (first @*active-threads*))
+             (and (true? thread) (seq @active-threads))
+             (.stop #^Thread (first @active-threads))
               (= thread :repl-thread) (.stop #^Thread @(conn :repl-thread)))))
          :else
          nil))))

--- a/src/swank/core.clj
+++ b/src/swank/core.clj
@@ -270,7 +270,7 @@ values."
 
       :else
       (do
-        (set! *e t)
+        ;; (set! *e t)
         (try
          (sldb-debug
           nil

--- a/src/swank/core/connection.clj
+++ b/src/swank/core/connection.clj
@@ -5,8 +5,8 @@
   (:import (java.net ServerSocket Socket InetAddress)
            (java.io InputStreamReader OutputStreamWriter)))
 
-(def *current-connection*)
-(def *default-encoding* "iso-8859-1")
+(def ^:dynamic *current-connection*)
+(def default-encoding "iso-8859-1")
 
 (defmacro with-connection [conn & body]
   `(binding [*current-connection* ~conn] ~@body))
@@ -32,11 +32,11 @@
    argument `encoding' to define the encoding of the connection. If
    encoding is nil, then the default encoding will be used.
 
-   See also: `*default-encoding*', `start-server-socket!'"
-  ([#^Socket socket] (make-connection socket *default-encoding*))
+   See also: `default-encoding', `start-server-socket!'"
+  ([#^Socket socket] (make-connection socket default-encoding))
   ([#^Socket socket encoding]
      (let [#^String
-           encoding (or (encoding-map encoding encoding) *default-encoding*)]
+           encoding (or (encoding-map encoding encoding) default-encoding)]
        {:socket socket
         :reader (InputStreamReader. (.getInputStream socket) encoding)
         :writer (OutputStreamWriter. (.getOutputStream socket) encoding)

--- a/src/swank/core/connection.clj
+++ b/src/swank/core/connection.clj
@@ -5,7 +5,7 @@
   (:import (java.net ServerSocket Socket InetAddress)
            (java.io InputStreamReader OutputStreamWriter)))
 
-(def ^:dynamic *current-connection*)
+(def #^{:dynamic true} *current-connection*)
 (def default-encoding "iso-8859-1")
 
 (defmacro with-connection [conn & body]

--- a/src/swank/core/hooks.clj
+++ b/src/swank/core/hooks.clj
@@ -1,4 +1,4 @@
 (ns swank.core.hooks
   (:use (swank.util hooks)))
 
-(defhook *pre-reply-hook*)
+(defhook pre-reply-hook)

--- a/src/swank/core/protocol.clj
+++ b/src/swank/core/protocol.clj
@@ -5,12 +5,12 @@
 
 ;; Read forms
 (def #^{:private true}
-     *namespace-re* #"(^\(:emacs-rex \([a-zA-Z][a-zA-Z0-9]+):")
+     namespace-re #"(^\(:emacs-rex \([a-zA-Z][a-zA-Z0-9]+):")
 
 (defn- fix-namespace
   "Changes the namespace of a function call from pkg:fn to ns/fn. If
    no pkg exists, then nothing is done."
-  ([text] (.replaceAll (re-matcher *namespace-re* text) "$1/")))
+  ([text] (.replaceAll (re-matcher namespace-re text) "$1/")))
 
 (defn write-swank-message
   "Given a `writer' (java.io.Writer) and a `message' (typically an

--- a/src/swank/core/protocol.clj
+++ b/src/swank/core/protocol.clj
@@ -40,7 +40,11 @@
   ([#^java.io.Reader reader]
      (let [len  (Integer/parseInt (read-chars reader 6 read-fail-exception) 16)
            msg  (read-chars reader len read-fail-exception)
-           form (read-string (fix-namespace msg))]
+           form (try
+                  (read-string (fix-namespace msg))
+                  (catch Exception ex
+                    (.println System/err (format "unreadable message: %s" msg))
+                    (throw ex)))]
        (if (seq? form)
          (deep-replace {'t true} form)
          form))))

--- a/src/swank/core/server.clj
+++ b/src/swank/core/server.clj
@@ -13,7 +13,7 @@
 ;;  - Creates swank.core.connections
 ;;  - Spins up new threads
 
-(defonce *connections* (ref []))
+(defonce connections (ref []))
 
 (def slime-secret-path (str (user-home-path) File/separator ".slime-secret"))
 
@@ -40,7 +40,7 @@
 
    See also: `slime-secret'"
   ([#^Socket socket opts]
-     (returning [conn (make-connection socket (get opts :encoding *default-encoding*))]
+     (returning [conn (make-connection socket (get opts :encoding default-encoding))]
        (if-let [secret (slime-secret)]
          (when-not (= (read-from-connection conn) secret)
            (close-socket! socket))
@@ -60,7 +60,7 @@
       (binding [*out* out-redir
                 *err* out-redir]
         (dosync (ref-set (*current-connection* :writer-redir) *out*))
-        (dosync (alter *connections* conj *current-connection*))
+        (dosync (alter connections conj *current-connection*))
         (connection-serve *current-connection*)))))
 
 ;; Setup frontent

--- a/src/swank/core/server.clj
+++ b/src/swank/core/server.clj
@@ -84,7 +84,7 @@
   [port announce-fn connection-serve opts]
   (start-swank-socket-server!
    (make-server-socket {:port    port
-                        :host    (opts :host)
+                        :host    (opts :host "localhost")
                         :backlog (opts :backlog 0)})
    #(socket-serve connection-serve % opts)
    {:announce announce-fn}))

--- a/src/swank/core/threadmap.clj
+++ b/src/swank/core/threadmap.clj
@@ -2,22 +2,22 @@
   (:use (swank util)
         (swank.util.concurrent thread)))
 
-(defonce *thread-map-next-id* (ref 1))
-(defonce *thread-map* (ref {}))
+(defonce thread-map-next-id (ref 1))
+(defonce thread-map (ref {}))
 
 (defn- thread-map-clean []
-  (doseq [[id t] @*thread-map*]
+  (doseq [[id t] @thread-map]
     (when (or (nil? t)
               (not (thread-alive? t)))
       (dosync
-       (alter *thread-map* dissoc id)))))
+       (alter thread-map dissoc id)))))
 
 (defn- get-thread-id [thread]
-  (if-let [entry (find-first #(= (val %) thread) @*thread-map*)]
+  (if-let [entry (find-first #(= (val %) thread) @thread-map)]
     (key entry)
-    (let [next-id @*thread-map-next-id*]
-      (alter *thread-map* assoc next-id thread)
-      (alter *thread-map-next-id* inc)
+    (let [next-id @thread-map-next-id]
+      (alter thread-map assoc next-id thread)
+      (alter thread-map-next-id inc)
       next-id)))
 
 (defn thread-map-id [thread]
@@ -25,5 +25,5 @@
     (thread-map-clean)))
 
 (defn find-thread [id]
-  (@*thread-map* id))
+  (@thread-map id))
 

--- a/src/swank/dev.clj
+++ b/src/swank/dev.clj
@@ -2,5 +2,5 @@
   (:use (swank util)))
 
 (defmacro with-swank-io [& body]
-  `(binding [*out* @(:writer-redir (first @swank.core.server/*connections*))]
+  `(binding [*out* @(:writer-redir (first @swank.core.server/connections))]
      ~@body))

--- a/src/swank/rpc.clj
+++ b/src/swank/rpc.clj
@@ -1,5 +1,102 @@
 ;;; This code has been placed in the Public Domain.  All warranties are disclaimed.
-(ns #^{:doc "Pass remote calls and responses between lisp systems using the swank-rpc protocol."       :author "Terje Norderhaug <terje@in-progress.com>"}  swank.rpc  (:use (swank util)        (swank.util io))  (:import (java.io Writer Reader PushbackReader StringReader)));; ERROR HANDLING(def swank-protocol-error (Exception. "Swank protocol error."));; LOGGING(def *log-events* false)(def *log-output* nil)(defn log-event [format-string & args]  (when *log-events*     (.write (or *log-output* *out*) (apply format format-string args))    (.flush (or *log-output* *out*))    nil));; INPUT(defn- read-form   "Read a form that conforms to the swank rpc protocol"  ([#^Reader rdr]    (let [c (.read rdr)]          (condp = (char c)          \" (let [sb (StringBuilder.)]               (loop []                 (let [c (.read rdr)]                 (if (= c -1)                   (throw (java.io.EOFException. "Incomplete reading of quoted string."))                   (condp = (char c)                     \" (str sb)                     \\ (do (.append sb (char (.read rdr)))                            (recur))                    (do (.append sb (char c))                         (recur)))))))          \( (loop [result []]               (let [form (read-form rdr)]                     (let [c (.read rdr)]                       (if (= c -1)                         (throw (java.io.EOFException. "Incomplete reading of list."))                         (condp = (char c)                           \) (sequence (conj result form))                           \space (recur (conj result form)))))))          \' (list 'quote (read-form rdr))          (let [sb (StringBuilder.)]            (loop [c c]              (if (not= c -1)                (condp = (char c)                  \\ (do (.append sb (char (.read rdr)))                          (recur (.read rdr)))                  \space (.unread rdr c)                  \) (.unread rdr c)                  (do (.append sb (char c))                       (recur (.read rdr))))))            (let [str (str sb)]                   (cond                (. Character isDigit c) (Integer/parseInt str)                (= "nil" str) nil                (= "t" str) true                :else (symbol str))))))))(defn- read-packet  ([#^Reader reader]     (let [len (Integer/parseInt (read-chars reader 6 swank-protocol-error) 16)]       (read-chars reader len swank-protocol-error)))) (defn decode-message   "Read an rpc message encoded using the swank rpc protocol."   ([#^Reader rdr]    (let [packet (read-packet rdr)]       (log-event "READ: %s\n" packet)       (try         (with-open [rdr (PushbackReader. (StringReader. packet))]           (read-form rdr))         (catch Exception e           (list :reader-error packet e)))))); (with-open [rdr (StringReader. "00001f(swank:a 123 (%b% (t nil) \"c\"))")] (decode-message rdr))        ;; OUTPUT(defmulti print-object (fn [x writer] (type x)))(defmethod print-object :default [o, #^Writer w]  (print-method o w))(defmethod print-object Boolean [o, #^Writer w]  (.write w (if o "t" "nil")))(defmethod print-object String [#^String s, #^Writer w]  (let [char-escape-string {\" "\\\""
+(ns #^{:doc "Pass remote calls and responses between lisp systems using the swank-rpc protocol."
+       :author "Terje Norderhaug <terje@in-progress.com>"}
+  swank.rpc
+  (:use (swank util)
+        (swank.util io))
+  (:import (java.io Writer Reader PushbackReader StringReader)))
+
+;; ERROR HANDLING
+
+(def swank-protocol-error (Exception. "Swank protocol error."))
+
+;; LOGGING
+
+(def *log-events* false)
+
+(def *log-output* nil)
+
+(defn log-event [format-string & args]
+  (when *log-events*
+    (.write (or *log-output* *out*) (apply format format-string args))
+    (.flush (or *log-output* *out*))
+    nil))
+
+;; INPUT
+
+(defn- read-form
+   "Read a form that conforms to the swank rpc protocol"
+  ([#^Reader rdr]
+    (let [c (.read rdr)]
+      (condp = (char c)
+          \" (let [sb (StringBuilder.)]
+               (loop []
+                (let [c (.read rdr)]
+                 (if (= c -1)
+                   (throw (java.io.EOFException. "Incomplete reading of quoted string."))
+                   (condp = (char c)
+                     \" (str sb)
+                     \\ (do (.append sb (char (.read rdr)))
+                            (recur))
+                    (do (.append sb (char c))
+                        (recur)))))))
+          \( (loop [result []]
+               (let [form (read-form rdr)]
+                     (let [c (.read rdr)]
+                       (if (= c -1)
+                         (throw (java.io.EOFException. "Incomplete reading of list."))
+                         (condp = (char c)
+                           \) (sequence (conj result form))
+                           \space (recur (conj result form)))))))
+          \' (list 'quote (read-form rdr))
+          (let [sb (StringBuilder.)]
+            (loop [c c]
+              (if (not= c -1)
+                (condp = (char c)
+                  \\ (do (.append sb (char (.read rdr)))
+                         (recur (.read rdr)))
+                  \space (.unread rdr c)
+                  \) (.unread rdr c)
+                  (do (.append sb (char c))
+                      (recur (.read rdr))))))
+            (let [str (str sb)]
+              (cond
+                (. Character isDigit c) (Integer/parseInt str)
+                (= "nil" str) nil
+                (= "t" str) true
+                :else (symbol str))))))))
+
+(defn- read-packet
+  ([#^Reader reader]
+     (let [len (Integer/parseInt (read-chars reader 6 swank-protocol-error) 16)]
+       (read-chars reader len swank-protocol-error))))
+
+(defn decode-message
+   "Read an rpc message encoded using the swank rpc protocol."
+  ([#^Reader rdr]
+    (let [packet (read-packet rdr)]
+       (log-event "READ: %s\n" packet)
+       (try
+         (with-open [rdr (PushbackReader. (StringReader. packet))]
+           (read-form rdr))
+         (catch Exception e
+           (list :reader-error packet e))))))
+
+; (with-open [rdr (StringReader. "00001f(swank:a 123 (%b% (t nil) \"c\"))")] (decode-message rdr))
+
+
+;; OUTPUT
+
+(defmulti print-object (fn [x writer] (type x)))
+
+(defmethod print-object :default [o, #^Writer w]
+  (print-method o w))
+
+(defmethod print-object Boolean [o, #^Writer w]
+  (.write w (if o "t" "nil")))
+
+(defmethod print-object String [#^String s, #^Writer w]
+  (let [char-escape-string {\" "\\\""
                             \\  "\\\\"}]
     (do (.append w \")
       (dotimes [n (count s)]
@@ -7,4 +104,56 @@
               e (char-escape-string c)]
           (if e (.write w e) (.append w c))))
       (.append w \"))
-  nil))(defmethod print-object clojure.lang.ISeq [o, #^Writer w]  (.write w "(")  (print-object (first o) w)  (doseq [item (rest o)]    (.write w " ")    (print-object item w))  (.write w ")"))(defn- write-form  ([#^Writer writer message]    (print-object message writer)))(defn- write-packet  ([#^Writer writer str]   (let [len (.length str)]    (doto writer          (.write (format "%06x" len))          (.write str)          (.flush)))))(defn encode-message  "Write an rpc message encoded using the swank rpc protocol."  ([#^Writer writer message]     (let [str (with-out-str                  (write-form *out* message)) ]       (log-event "WRITE: %s\n" str)       (write-packet writer str)))); (with-out-str (encode-message *out* "hello")); (with-out-str (encode-message *out* '(a 123 (swank:b (true false) "c"))));; DISPATCH(defonce rpc-fn-map {})(defn register-dispatch   ([name fn]    (register-dispatch name fn #'rpc-fn-map))  ([name fn fn-map]    (alter-var-root fn-map assoc name fn)))(defn dispatch-message  ([message fn-map]    (let [operation (first message)          operands (rest message)          fn (fn-map operation)]        (assert fn)        (apply fn operands)))  ([message]   (dispatch-message message rpc-fn-map)))              
+  nil))
+
+(defmethod print-object clojure.lang.ISeq [o, #^Writer w]
+  (.write w "(")
+  (print-object (first o) w)
+  (doseq [item (rest o)]
+    (.write w " ")
+    (print-object item w))
+  (.write w ")"))
+
+(defn- write-form
+  ([#^Writer writer message]
+    (print-object message writer)))
+
+(defn- write-packet
+  ([#^Writer writer str]
+   (let [len (.length str)]
+    (doto writer
+          (.write (format "%06x" len))
+          (.write str)
+          (.flush)))))
+
+(defn encode-message
+  "Write an rpc message encoded using the swank rpc protocol."
+  ([#^Writer writer message]
+     (let [str (with-out-str
+                  (write-form *out* message)) ]
+       (log-event "WRITE: %s\n" str)
+       (write-packet writer str))))
+
+; (with-out-str (encode-message *out* "hello"))
+; (with-out-str (encode-message *out* '(a 123 (swank:b (true false) "c"))))
+
+
+;; DISPATCH
+
+(defonce rpc-fn-map {})
+
+(defn register-dispatch
+  ([name fn]
+    (register-dispatch name fn #'rpc-fn-map))
+  ([name fn fn-map]
+    (alter-var-root fn-map assoc name fn)))
+
+(defn dispatch-message
+  ([message fn-map]
+    (let [operation (first message)
+          operands (rest message)
+          fn (fn-map operation)]
+        (assert fn)
+        (apply fn operands)))
+  ([message]
+   (dispatch-message message rpc-fn-map)))

--- a/src/swank/rpc.clj
+++ b/src/swank/rpc.clj
@@ -12,14 +12,14 @@
 
 ;; LOGGING
 
-(def *log-events* false)
+(def log-events false)
 
-(def *log-output* nil)
+(def log-output nil)
 
 (defn log-event [format-string & args]
-  (when *log-events*
-    (.write (or *log-output* *out*) (apply format format-string args))
-    (.flush (or *log-output* *out*))
+  (when log-events
+    (.write (or log-output *out*) (apply format format-string args))
+    (.flush (or log-output *out*))
     nil))
 
 ;; INPUT

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -86,7 +86,7 @@
                                                 (File. "slime-port.txt")
                                                 (.getCanonicalPath))
                                             ~@(apply concat opts)))))
-             :need-prompt #(identity false))))
+             :need-prompt (constantly false))))
   ([] (start-repl 4005)))
 
 (def -main start-repl)

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -61,7 +61,7 @@
   "Start the server wrapped in a repl. Use this to embed swank in your code."
   ([port & opts]
      (let [stop (atom false)
-           opts (merge {:port port
+           opts (merge {:port (Integer. port)
                         :encoding (or (System/getProperty
                                        "swank.encoding")
                                       "iso-latin-1-unix")}

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -21,7 +21,7 @@
   (:gen-class))
 
 (defn ignore-protocol-version [version]
-  (reset! *protocol-version* version))
+  (reset! protocol-version version))
 
 (defn- connection-serve [conn]
   (let [control
@@ -40,7 +40,7 @@
            (catch Exception e
              ;; This could be put somewhere better
              (.interrupt control)
-             (dosync (alter *connections* (partial remove #{conn}))))))]
+             (dosync (alter connections (partial remove #{conn}))))))]
     (dosync
      (ref-set (conn :control-thread) control)
      (ref-set (conn :read-thread) read))))

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -20,6 +20,9 @@
            [java.io File])
   (:gen-class))
 
+(defn ignore-protocol-version [version]
+  (reset! *protocol-version* version))
+
 (defn- connection-serve [conn]
   (let [control
         (dothread-swank

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -57,13 +57,21 @@
                   connection-serve
                   opts)))
 
+(def #^{:private true} encodings-map
+  {"UTF-8" "utf-8-unix"
+   })
+
+(defn- get-system-encoding []
+  (when-let [enc-name (.name (java.nio.charset.Charset/defaultCharset))]
+    (encodings-map enc-name)))
+
 (defn start-repl
   "Start the server wrapped in a repl. Use this to embed swank in your code."
   ([port & opts]
      (let [stop (atom false)
            opts (merge {:port (Integer. port)
-                        :encoding (or (System/getProperty
-                                       "swank.encoding")
+                        :encoding (or (System/getProperty "swank.encoding")
+                                      (get-system-encoding)
                                       "iso-latin-1-unix")}
                        (apply hash-map opts))]
        (repl :read (fn [rprompt rexit]

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -12,6 +12,7 @@
   (:use [swank.core]
         [swank.core connection server]
         [swank.util.concurrent thread]
+        [swank.util.net sockets]
         [clojure.main :only [repl]])
   (:require [swank.commands]
             [swank.commands basic indent completion
@@ -31,7 +32,8 @@
            (control-loop conn)
            (catch Exception e
              ;; fail silently
-             nil)))
+             nil))
+          (close-socket! (conn :socket)))
         read
         (dothread-swank
           (thread-set-name "Read Loop Thread")

--- a/src/swank/swank.clj
+++ b/src/swank/swank.clj
@@ -39,6 +39,8 @@
            (read-loop conn control)
            (catch Exception e
              ;; This could be put somewhere better
+             (.println System/err "exception in read loop")
+             (.printStackTrace e)
              (.interrupt control)
              (dosync (alter connections (partial remove #{conn}))))))]
     (dosync

--- a/src/swank/util/concurrent/mbox.clj
+++ b/src/swank/util/concurrent/mbox.clj
@@ -2,17 +2,17 @@
   (:refer-clojure :exclude [send get]))
 
 ;; Holds references to the mailboxes (message queues)
-(defonce *mailboxes* (ref {}))
+(defonce mailboxes (ref {}))
 
 (defn get
   "Returns the mailbox for a given id. Creates one if one does not
    already exist."
   ([id]
      (dosync
-      (when-not (@*mailboxes* id)
-        (alter *mailboxes* assoc
+      (when-not (@mailboxes id)
+        (alter mailboxes assoc
                id (java.util.concurrent.LinkedBlockingQueue.))))
-     (@*mailboxes* id))
+     (@mailboxes id))
   {:tag java.util.concurrent.LinkedBlockingQueue})
 
 (defn send

--- a/src/swank/util/concurrent/thread.clj
+++ b/src/swank/util/concurrent/thread.clj
@@ -17,7 +17,9 @@
   `(start-thread (keep-bindings ~bindings (fn [] ~@body))))
 
 (defmacro dothread-keeping-clj [more-bindings & body]
-  (let [clj-star-syms (filter #(.startsWith #^String (name %) "*")
+  (let [clj-star-syms (filter #(and (.startsWith #^String (name %) "*")
+                                    (.endsWith #^String (name %) "*")
+                                    (> (count (name %)) 1))
                               (keys (ns-publics (find-ns 'clojure.core))))]
     `(dothread-keeping [~@clj-star-syms ~@more-bindings]
        ~@body)))

--- a/src/swank/util/concurrent/thread.clj
+++ b/src/swank/util/concurrent/thread.clj
@@ -17,9 +17,13 @@
   `(start-thread (keep-bindings ~bindings (fn [] ~@body))))
 
 (defmacro dothread-keeping-clj [more-bindings & body]
-  (let [clj-star-syms (filter #(and (.startsWith #^String (name %) "*")
-                                    (.endsWith #^String (name %) "*")
-                                    (> (count (name %)) 1))
+  (let [clj-star-syms (filter #(or (= (name %) "*e")
+                                   (= (name %) "*1")
+                                   (= (name %) "*2")
+                                   (= (name %) "*3")
+                                   (and (.startsWith #^String (name %) "*")
+                                        (.endsWith #^String (name %) "*")
+                                        (> (count (name %)) 1)))
                               (keys (ns-publics (find-ns 'clojure.core))))]
     `(dothread-keeping [~@clj-star-syms ~@more-bindings]
        ~@body)))

--- a/src/swank/util/io.clj
+++ b/src/swank/util/io.clj
@@ -6,14 +6,15 @@
 (defn read-chars
   ([rdr n] (read-chars rdr n false))
   ([#^Reader rdr n throw-exception]
-     (let [sb (StringBuilder.)]
-       (dotimes [i n]
-         (let [c (.read rdr)]
-           (if (not= c -1)
-             (.append sb (char c))
-             (when throw-exception
-               (throw throw-exception)))))
-       (str sb))))
+     (let [cbuf (make-array Character/TYPE n)]
+       (loop [i 0]
+	 (let [size (.read rdr cbuf i (- n i))]
+	   (cond
+	    (neg? size) (if throw-exception
+			  (throw throw-exception)
+			  (String. cbuf 0 i))
+	    (= (+ i size) n) (String. cbuf)
+	    :else (recur (+ i size))))))))
 
 (defn call-on-flush-stream
   "Creates a stream that will call a given function when flushed."


### PR DESCRIPTION
The version of print-doc introduced in 527a6d9fa36ecd089f22a755749d7efdf07772da takes a var's metadata map as its argument, not the var itself.
